### PR TITLE
CRM-988: Relocate "Unsubscribe" Link to the Footer

### DIFF
--- a/chtemplate/chtemplate.html
+++ b/chtemplate/chtemplate.html
@@ -1595,8 +1595,7 @@
   <tr>
     <td class="vb-outer" align="center" valign="top" style="padding-left: 9px; padding-right: 9px; font-size: 0">
       <!--[if (gte mso 9)|(lte ie 8)]><table role="presentation" align="center" border="0" cellspacing="0" cellpadding="0" width="570"><tr><td align="center" valign="top"><![endif]-->
-      <!--
--->
+      
       <div style="margin: 0 auto; max-width: 570px; -mru-width: 0px">
         <table border="0" cellpadding="0" cellspacing="0"
           style="border-collapse: separate; width: 100%; mso-cellspacing: 0px; border-spacing: 0px; max-width: 570px; -mru-width: 0px"
@@ -1605,8 +1604,7 @@
           <tr>
             <td align="left" valign="top" style="font-size: 0; padding: 0 9px">
               <div style="vertical-align:top; width:100%; max-width: 552px; -mru-width: 0px">
-                <!--
-  -->
+                
                 <table class="vb-content" border="0" cellspacing="9" cellpadding="0"
                   style="border-collapse: separate; width: 100%; mso-cellspacing: 9px; border-spacing: 9px"
                   width="552">


### PR DESCRIPTION
Made changes in HTML template to relocate "Unsubscribe" link. Removed "Unsubscribe" link from preHeader block and re-aligned "View in you browser" link to the left. Added new footerBlock which contains "Unsubscribe" link that is pre-loaded and default. Removed "PreHeader Text" and its value from preHeader Block.