### PR TITLE
CRM-988-1 : Relocate Unsubscribe Link to the Footer, Path changes

### DIFF
--- a/CRM/Chmosaicotemplate/Upgrader.php
+++ b/CRM/Chmosaicotemplate/Upgrader.php
@@ -130,6 +130,37 @@ class CRM_Chmosaicotemplate_Upgrader extends CRM_Chmosaicotemplate_Upgrader_Base
     return TRUE;
   }
 
+  public function upgrade_1203() {
+    $this->ctx->log->info('CRM-988: Relocate "Unsubscribe" Link to the Footer');
+   //Replacing uk.co.vedaconsulting.mosaico template path with biz.jmaconsulting.chmosaicotemplate for canadahelps base(Basic) templates (4 templates)
+    $whereClauses = [
+      [
+        'searchString' => 'common/uk.co.vedaconsulting.mosaico/packages/mosaico/templates/versafix-1/template-versafix-1.html',
+        'searchClause' => "metadata LIKE '%common/uk.co.vedaconsulting.mosaico/packages/mosaico/templates/versafix-1/template-versafix-1.html%'",
+        'replaceString' => 'common/biz.jmaconsulting.chmosaicotemplate/chtemplate/chtemplate.html',
+      ],
+      [
+        'searchString' => 'vendor/civicrm/uk.co.vedaconsulting.mosaico/packages/mosaico/templates/versafix-1/template-versafix-1.html',
+        'searchClause' => "metadata LIKE '%vendor/civicrm/uk.co.vedaconsulting.mosaico/packages/mosaico/templates/versafix-1/template-versafix-1.html%'",
+        'replaceString' => 'vendor/civicrm/zz-canadahelps/biz.jmaconsulting.chmosaicotemplate/chtemplate/chtemplate.html',
+      ]
+    ];
+    foreach($whereClauses as $whereClause) {
+     
+     $queryValue = CRM_Core_DAO::executeQuery(sprintf("SELECT metadata, id from `civicrm_mosaico_template` WHERE %s ", $whereClause['searchClause']));
+     while($queryValue->fetch())
+     {
+       $metavalue_array = json_decode($queryValue->metadata,TRUE);
+       $metavalue_array['template'] = str_replace($whereClause['searchString'], $whereClause['replaceString'], $metavalue_array['template']);
+       $updated_metavalue = json_encode($metavalue_array);
+       CRM_Core_DAO::executeQuery(sprintf("UPDATE civicrm_mosaico_template SET metadata = '%s' WHERE id = %s ", $updated_metavalue, $queryValue->id));
+      
+    }
+    
+  }
+   return TRUE;
+}
+
   public function fixUpBasicThankYouTemplate() {
     $thankYouTemplate = civicrm_api3('MessageTemplate', 'get', [
       'msg_title' => 'Basic - Thank You Email',

--- a/CRM/Chmosaicotemplate/Upgrader.php
+++ b/CRM/Chmosaicotemplate/Upgrader.php
@@ -159,7 +159,7 @@ class CRM_Chmosaicotemplate_Upgrader extends CRM_Chmosaicotemplate_Upgrader_Base
     
   }
    return TRUE;
-}
+  }
 
   public function fixUpBasicThankYouTemplate() {
     $thankYouTemplate = civicrm_api3('MessageTemplate', 'get', [

--- a/CRM/Chmosaicotemplate/Upgrader.php
+++ b/CRM/Chmosaicotemplate/Upgrader.php
@@ -146,7 +146,6 @@ class CRM_Chmosaicotemplate_Upgrader extends CRM_Chmosaicotemplate_Upgrader_Base
       ]
     ];
     foreach($whereClauses as $whereClause) {
-     
      $queryValue = CRM_Core_DAO::executeQuery(sprintf("SELECT metadata, id from `civicrm_mosaico_template` WHERE %s ", $whereClause['searchClause']));
      while($queryValue->fetch())
      {
@@ -154,10 +153,8 @@ class CRM_Chmosaicotemplate_Upgrader extends CRM_Chmosaicotemplate_Upgrader_Base
        $metavalue_array['template'] = str_replace($whereClause['searchString'], $whereClause['replaceString'], $metavalue_array['template']);
        $updated_metavalue = json_encode($metavalue_array);
        CRM_Core_DAO::executeQuery(sprintf("UPDATE civicrm_mosaico_template SET metadata = '%s' WHERE id = %s ", $updated_metavalue, $queryValue->id));
-      
+      }
     }
-    
-  }
    return TRUE;
   }
 


### PR DESCRIPTION
uk.co.vedaconsulting.mosaico has 4 basic templates [ Basic - Email No Gallery , Basic - Email With Gallery, Basic - Newsletter, Basic - Text Only]. Updated biz.jmaconsulting.chmosaicotemplate extension with changes such as relocating Unsubscribe link to footer, re-aligned "View in you browser" link to the left, removed "PreHeader Text" and its value from preHeader Block. Made changes in path so now every template being read from chmosaicotemplate extension instead of vedaconsulting extension.